### PR TITLE
A few changes for building binaryen within eosio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,30 +2,25 @@ PROJECT(binaryen C CXX)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7)
 INCLUDE(GNUInstallDirs)
 
-IF(NOT CMAKE_BUILD_TYPE)
-  MESSAGE(STATUS "No build type selected, default to Release")
-  SET(CMAKE_BUILD_TYPE "Release")
-ENDIF()
-
-OPTION(BUILD_STATIC_LIB "Build as a static library" OFF)
+set(BUILD_STATIC_LIB ON)
 
 # Support functionality.
 
 FUNCTION(ADD_COMPILE_FLAG value)
-  MESSAGE(STATUS "Building with ${value}")
+  MESSAGE(STATUS "binaryen building with ${value}")
   FOREACH(variable CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
     SET(${variable} "${${variable}} ${value}" PARENT_SCOPE)
   ENDFOREACH(variable)
 ENDFUNCTION()
 
 FUNCTION(ADD_CXX_FLAG value)
-  MESSAGE(STATUS "Building with ${value}")
+  MESSAGE(STATUS "binaryen building with ${value}")
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${value}" PARENT_SCOPE)
 ENDFUNCTION()
 
 FUNCTION(ADD_DEBUG_COMPILE_FLAG value)
   IF("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-    MESSAGE(STATUS "Building with ${value}")
+    MESSAGE(STATUS "binaryen building with ${value}")
   ENDIF()
   FOREACH(variable CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
     SET(${variable} "${${variable}} ${value}" PARENT_SCOPE)
@@ -34,7 +29,7 @@ ENDFUNCTION()
 
 FUNCTION(ADD_NONDEBUG_COMPILE_FLAG value)
   IF(NOT "${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-    MESSAGE(STATUS "Building with ${value}")
+    MESSAGE(STATUS "binaryen building with ${value}")
   ENDIF()
   FOREACH(variable CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
     SET(${variable} "${${variable}} ${value}" PARENT_SCOPE)
@@ -42,7 +37,7 @@ FUNCTION(ADD_NONDEBUG_COMPILE_FLAG value)
 ENDFUNCTION()
 
 FUNCTION(ADD_LINK_FLAG value)
-  MESSAGE(STATUS "Linking with ${value}")
+  MESSAGE(STATUS "binaryen linking with ${value}")
   FOREACH(variable CMAKE_EXE_LINKER_FLAGS)
     SET(${variable} "${${variable}} ${value}" PARENT_SCOPE)
   ENDFOREACH(variable)
@@ -130,7 +125,7 @@ ELSE()
           message(WARNING "Unknown target architecture!")
         endif ()
         if(TARGET_ARCH)
-          MESSAGE(STATUS "Building for platform ${TARGET_ARCH}")
+          MESSAGE(STATUS "binaryen building for platform ${TARGET_ARCH}")
         endif ()
       else ()
         message(WARNING "Error running file on dummy executable")
@@ -191,95 +186,15 @@ IF(BUILD_STATIC_LIB)
 ELSE()
   ADD_LIBRARY(binaryen SHARED ${binaryen_SOURCES})
 ENDIF()
-TARGET_LINK_LIBRARIES(binaryen ${all_passes} wasm asmjs ast cfg support)
-INSTALL(TARGETS binaryen DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-INSTALL(FILES src/binaryen-c.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-INSTALL(FILES bin/wasm.js DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
-INSTALL(FILES bin/binaryen.js DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
-
-SET(wasm-shell_SOURCES
-  src/tools/wasm-shell.cpp
-  src/wasm-interpreter.cpp
-)
-ADD_EXECUTABLE(wasm-shell
-               ${wasm-shell_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-shell wasm asmjs emscripten-optimizer ${all_passes} ast cfg support)
-SET_PROPERTY(TARGET wasm-shell PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET wasm-shell PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS wasm-shell DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-SET(wasm-opt_SOURCES
-  src/tools/wasm-opt.cpp
-  src/wasm-interpreter.cpp
-)
-ADD_EXECUTABLE(wasm-opt
-               ${wasm-opt_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-opt wasm asmjs emscripten-optimizer ${all_passes} ast cfg support)
-SET_PROPERTY(TARGET wasm-opt PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET wasm-opt PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS wasm-opt DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-SET(wasm-merge_SOURCES
-  src/tools/wasm-merge.cpp
-)
-ADD_EXECUTABLE(wasm-merge
-               ${wasm-merge_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-merge wasm asmjs emscripten-optimizer ${all_passes} ast cfg support)
-SET_PROPERTY(TARGET wasm-merge PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET wasm-merge PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS wasm-merge DESTINATION bin)
-
-SET(asm2wasm_SOURCES
-  src/tools/asm2wasm.cpp
-  src/wasm-emscripten.cpp
-)
-ADD_EXECUTABLE(asm2wasm
-               ${asm2wasm_SOURCES})
-TARGET_LINK_LIBRARIES(asm2wasm emscripten-optimizer ${all_passes} wasm asmjs ast cfg support)
-SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS asm2wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 SET(s2wasm_SOURCES
   src/tools/s2wasm.cpp
   src/wasm-emscripten.cpp
   src/wasm-linker.cpp
 )
-ADD_EXECUTABLE(s2wasm
+ADD_EXECUTABLE(eosio-s2wasm
                ${s2wasm_SOURCES})
-TARGET_LINK_LIBRARIES(s2wasm passes wasm asmjs ast cfg support)
-SET_PROPERTY(TARGET s2wasm PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET s2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS s2wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-SET(wasm_as_SOURCES
-  src/tools/wasm-as.cpp
-)
-ADD_EXECUTABLE(wasm-as
-               ${wasm_as_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-as wasm asmjs passes ast cfg support)
-SET_PROPERTY(TARGET wasm-as PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET wasm-as PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS wasm-as DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-SET(wasm_dis_SOURCES
-  src/tools/wasm-dis.cpp
-)
-ADD_EXECUTABLE(wasm-dis
-               ${wasm_dis_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-dis passes wasm asmjs ast cfg support)
-SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS wasm-dis DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-SET(wasm-ctor-eval_SOURCES
-  src/tools/wasm-ctor-eval.cpp
-)
-ADD_EXECUTABLE(wasm-ctor-eval
-               ${wasm-ctor-eval_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-ctor-eval wasm asmjs emscripten-optimizer ${all_passes} ast cfg support)
-SET_PROPERTY(TARGET wasm-ctor-eval PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET wasm-ctor-eval PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS wasm-ctor-eval DESTINATION bin)
-
+TARGET_LINK_LIBRARIES(eosio-s2wasm passes wasm asmjs ast cfg support)
+SET_PROPERTY(TARGET eosio-s2wasm PROPERTY CXX_STANDARD 11)
+SET_PROPERTY(TARGET eosio-s2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
+INSTALL(TARGETS eosio-s2wasm DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
* Change some cmake messages to make it clear only binaryen is being built with some particular flags
* Rename s2wasm to eosio-s2wasm
* Make eosio-s2wasm built statically
* Remove installation of anything but eosio-s2wasm