### PR TITLE
Fix uninitialized branch in binaryen's Load opcode handler

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -395,7 +395,7 @@ public:
   Load(MixedArena& allocator) {}
 
   uint8_t bytes;
-  bool signed_;
+  bool signed_    = false;
   Address offset;
   Address align;
   Expression* ptr;


### PR DESCRIPTION
There is a boolean signed_ in binaryen's Load class that is checked against during the interpreter;s load opcode handler. However, this signed_ boolean is never initialized. Ultimately it should not matter as our implementation of loadXs and loadXu should be the same. Fixing it anyways.