### PR TITLE
 Update call_indirect text syntax to match spec update (#1281)

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -261,7 +261,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printCallBody(curr);
   }
   void visitCallIndirect(CallIndirect *curr) {
-    printOpening(o, "call_indirect ") << curr->fullType;
+    printOpening(o, "call_indirect (type ") << curr->fullType << ')';
     incIndent();
     for (auto operand : curr->operands) {
       printFullLine(operand);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1318,7 +1318,9 @@ Expression* SExpressionWasmBuilder::makeCallImport(Element& s) {
 Expression* SExpressionWasmBuilder::makeCallIndirect(Element& s) {
   if (!wasm.table.exists) throw ParseException("no table");
   auto ret = allocator.alloc<CallIndirect>();
-  IString type = s[1]->str();
+  Element& typeElement = *s[1];
+  if (typeElement[0]->str() != "type") throw ParseException("expected 'type' in call_indirect", s.line, s.col);
+  IString type = typeElement[1]->str();
   auto* fullType = wasm.getFunctionTypeOrNull(type);
   if (!fullType) throw ParseException("invalid call_indirect type", s.line, s.col);
   ret->fullType = fullType->name;


### PR DESCRIPTION
Function type gets its own element rather than being a part of the call_indirect
(see WebAssembly/spec#599)

EOSIO note: Only cherry-pick the .cpp changes for this. Trying to pull up the tests is not feasible. We don't use the tests anyways.