### PR TITLE
Move the “wasm stack” to the bottom of memory

### DIFF
--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -93,6 +93,9 @@ void Linker::layout() {
     }
   }
 
+  // Place the stack first, so any overrun is a page fault instead of corruption
+  if (stackAllocation) allocateStatic(stackAllocation, 16, ".stack");
+
   // Allocate all user statics
   for (const auto& obj : out.staticObjects) {
     allocateStatic(obj.allocSize, obj.alignment, obj.name);
@@ -104,10 +107,6 @@ void Linker::layout() {
     out.wasm.memory.segments[seg.second].offset = out.wasm.allocator.alloc<Const>()->set(Literal(uint32_t(address)));
     segmentsByAddress[address] = seg.second;
   }
-
-  // Place the stack after the user's static data, to keep those addresses
-  // small.
-  if (stackAllocation) allocateStatic(stackAllocation, 16, ".stack");
 
   // The minimum initial memory size is the amount of static variables we have
   // allocated. Round it up to a page, and update the page-increment versions


### PR DESCRIPTION
Move the wasm stack to the bottom of the linear memory. This has the benefit of causing a page fault when the stack overruns (due to wrap around to 0xffffffff which is always a fault in our environment) vs the current behavior of overrunning in to heap and other variables which tends to cause difficult to understand problems.

Example layout difference of the eosio.system contract

Previously:
```
0KB - 8KB; SP; strings, globals, etc
8KB - 16KB; first 8KB of heap
16KB - 26KB; 10KB of stack
26KB - 64KB; unused memory
```
With this commit:
```
0KB-10KB; 10KB of stack
10KB - 18KB; SP; strings; globals, etc
18KB - 26KB; first 8KB of heap
26KB - 64KB; unused memory
```